### PR TITLE
Add Firefox extension for PDF download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# articles
+# Articles Firefox Extension
+
+This repository contains a minimal Firefox extension that downloads the active tab as a PDF using metadata from Crossref to name the file.
+
+## How it works
+
+When you click the extension button, the URL of the current tab is treated as the PDF link. The extension queries [Crossref](https://api.crossref.org/) for metadata using any DOI found in the URL. The downloaded file is saved in the `Articles` folder of your browser downloads directory with a name of the form:
+
+```
+firstauthor-lastauthor-journal-year-title.pdf
+```
+
+If metadata cannot be retrieved, placeholder values are used.
+
+## Installation
+
+1. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on** and select the `manifest.json` file in the `firefox-extension` directory.
+3. Navigate to a PDF page and click the extension icon to download the file.

--- a/firefox-extension/background.js
+++ b/firefox-extension/background.js
@@ -1,0 +1,54 @@
+async function fetchMetadata(url) {
+  const doi = extractDoi(url);
+  if (!doi) return defaultMeta();
+  try {
+    const resp = await fetch('https://api.crossref.org/works/' + encodeURIComponent(doi));
+    if (!resp.ok) return defaultMeta();
+    const data = await resp.json();
+    const item = data.message;
+    const authors = item.author || [];
+    const firstAuthor = authors[0] ? authors[0].family || authors[0].given : 'unknown';
+    const lastAuthor = authors.length > 1 ? (authors[authors.length - 1].family || authors[authors.length - 1].given) : firstAuthor;
+    const journal = (item['container-title'] && item['container-title'][0]) || 'journal';
+    const year = (item.issued && item.issued['date-parts'] && item.issued['date-parts'][0][0]) || 'year';
+    const title = (item.title && item.title[0]) || 'title';
+    return { firstAuthor, lastAuthor, journal, year, title };
+  } catch (e) {
+    console.error('metadata fetch failed', e);
+    return defaultMeta();
+  }
+}
+
+function extractDoi(url) {
+  const match = url.match(/10\.\d{4,9}\/[^#?&]+/);
+  return match ? match[0] : null;
+}
+
+function buildFileName(meta) {
+  const sanitize = str => str.replace(/[^a-z0-9]+/gi, '_').replace(/^_+|_+$/g, '');
+  return [meta.firstAuthor, meta.lastAuthor, meta.journal, meta.year, meta.title]
+    .map(sanitize)
+    .join('-');
+}
+
+function defaultMeta() {
+  return { firstAuthor: 'first', lastAuthor: 'last', journal: 'journal', year: 'year', title: 'title' };
+}
+
+browser.browserAction.onClicked.addListener(async () => {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  const tab = tabs[0];
+  if (!tab || !tab.url) return;
+  const pdfUrl = tab.url;
+  const meta = await fetchMetadata(pdfUrl);
+  const fileName = buildFileName(meta) + '.pdf';
+  try {
+    await browser.downloads.download({
+      url: pdfUrl,
+      filename: 'Articles/' + fileName,
+      conflictAction: 'uniquify'
+    });
+  } catch (e) {
+    console.error('download failed', e);
+  }
+});

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 2,
+  "name": "PDF Downloader",
+  "version": "1.0",
+  "description": "Downloads PDF using first author - last author - journal - year - title naming.",
+  "applications": {
+    "gecko": {
+      "id": "pdf-downloader@example.com"
+    }
+  },
+  "permissions": [
+    "downloads",
+    "activeTab"
+  ],
+  "browser_action": {
+    "default_title": "Download PDF"
+  },
+  "background": {
+    "scripts": ["background.js"]
+  }
+}


### PR DESCRIPTION
## Summary
- add instructions and description to README
- implement Firefox extension for metadata-based PDF downloading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841fbb4809083249b52000177ccfed1