### PR TITLE
Add Siri-enabled reminder board app and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# articles
+# Reminder Board
+
+This repository contains everything needed to run a Siri-triggered reminder capture flow that transcribes your voice with OpenAI and pushes the text to a minimalist web display designed for an always-on iPad.
+
+## Repository layout
+
+```
+.
+├── ios/ReminderBoard/            # SwiftUI app distributed as a SwiftPM iOS application
+├── server/                       # FastAPI backend that stores reminders and serves the board UI
+└── README.md                     # This file
+```
+
+## iOS app
+
+The iOS target lives under `ios/ReminderBoard` and is defined as a Swift Package Manager iOS application. It uses:
+
+- **Siri shortcuts** via `CaptureReminderIntent` so you can say “Hey Siri, capture reminder in Reminder Board”.
+- **AVFoundation** to record raw audio in-app.
+- **OpenAI’s transcription endpoint** (`gpt-4o-mini-transcribe`) to convert audio to text.
+- **A configurable uploader** that POSTs the text to the backend service.
+
+### Configure secrets
+
+1. Open the package in Xcode (`File` → `Open Package...` and select `ios/ReminderBoard`).
+2. Add your OpenAI API key to the generated app target Info.plist by setting `OpenAIAPIKey` to your secret value. When using the SwiftPM app template you can also edit the `infoPlist` dictionary in `Package.swift` to inline the value during development (do **not** commit production keys).
+3. Update `ReminderUploader.Configuration.live.baseURL` in `ReminderUploader.swift` so it points at the machine running the FastAPI service (e.g. `http://192.168.1.42:8000`). If you want to require an API key, create a `server/API_KEY.txt` file and add the same value to the app so it can send it as the `X-API-Key` header.
+
+### Running in the simulator/device
+
+Because the project is SPM-based you can build and run from Xcode 15+: open the package and select the `ReminderBoard` scheme. The first run will request microphone permissions. The main screen has a large record button and shows the last reminder pushed to the board.
+
+## Backend service
+
+The backend is a lightweight FastAPI service that stores reminders in a JSON file and serves the minimalist board UI.
+
+### Setup
+
+```bash
+cd server
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn server.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+The service writes reminders to `server/data/reminders.json`. To protect the endpoint, optionally place an API key in `server/API_KEY.txt`; the iOS app will include it automatically if you set `ReminderUploader.Configuration.live.apiKey`.
+
+### API surface
+
+- `GET /reminders` returns the stored reminders (newest last).
+- `POST /reminders` accepts `{ "text": "Buy milk", "created_at": "2024-05-21T23:45:00Z" }`.
+- `GET /` serves the high-contrast wall display.
+
+## Wall display
+
+The `server/static/index.html` page is styled for legibility from a distance: large white text on a black background with subtle timestamps. Point the always-on iPad to the FastAPI server’s root URL (for example `http://192.168.1.42:8000/`). The page automatically refreshes every 30 seconds.
+
+## Siri setup
+
+After installing the iOS app, open Settings → Siri & Search → Shortcuts and add the “Capture reminder” shortcut that the app exposes. You can then trigger it hands-free: *“Hey Siri, capture reminder in Reminder Board”*. The app launches, starts recording, sends audio to OpenAI, and updates the board once the transcription returns.
+
+## Development notes
+
+- The OpenAI request uses multipart/form-data and targets `gpt-4o-mini-transcribe`. You can change the model name in `OpenAITranscriptionService` if you prefer a different transcription model.
+- The board retains the most recent 32 reminders; adjust `ReminderStore(max_items=...)` if you need a larger history.
+- For local testing without the OpenAI call you can swap in the preview mode by instantiating `ReminderCaptureCoordinator(preview: true)` inside `ReminderBoardApp`.

--- a/ios/ReminderBoard/Package.swift
+++ b/ios/ReminderBoard/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ReminderBoard",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .iOSApplication(
+            name: "ReminderBoard",
+            targets: ["AppModule"],
+            bundleIdentifier: "com.example.reminderboard",
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            iconAssetName: nil,
+            accentColorAssetName: nil,
+            supportedDeviceFamilies: [
+                .pad,
+                .phone
+            ],
+            supportedInterfaceOrientations: [
+                .portrait,
+                .portraitUpsideDown,
+                .landscapeLeft,
+                .landscapeRight
+            ],
+            infoPlist: [
+                "NSMicrophoneUsageDescription": .string("ReminderBoard records your voice so it can create reminders."),
+                "NSAppTransportSecurity": .dictionary([
+                    "NSAllowsArbitraryLoads": .boolean(true)
+                ])
+            ]
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "AppModule",
+            path: "Sources/AppModule",
+            resources: [
+                .process("Resources")
+            ]
+        )
+    ]
+)

--- a/ios/ReminderBoard/Sources/AppModule/ContentView.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ContentView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var captureCoordinator: ReminderCaptureCoordinator
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer()
+                RecordingVisualization(state: captureCoordinator.state)
+                Text(captureCoordinator.statusMessage)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 24)
+                Spacer()
+                RecordButton()
+                if let lastReminder = captureCoordinator.lastSuccessfulReminder {
+                    VStack(spacing: 12) {
+                        Text("Last reminder")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        Text(lastReminder)
+                            .font(.title3.weight(.medium))
+                            .multilineTextAlignment(.center)
+                            .transition(.opacity)
+                    }
+                    .padding()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(32)
+            .background(Color(uiColor: .systemBackground))
+            .navigationTitle("Reminder Board")
+        }
+        .onAppear {
+            captureCoordinator.bindToIntentNotifications()
+        }
+        .onDisappear {
+            captureCoordinator.unbindFromIntentNotifications()
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(ReminderCaptureCoordinator(preview: true))
+}

--- a/ios/ReminderBoard/Sources/AppModule/OpenAITranscriptionService.swift
+++ b/ios/ReminderBoard/Sources/AppModule/OpenAITranscriptionService.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct OpenAITranscriptionService {
+    enum ServiceError: LocalizedError {
+        case missingAPIKey
+        case invalidResponse
+        case transcriptionFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAPIKey:
+                return "OpenAI API key missing from configuration."
+            case .invalidResponse:
+                return "The transcription response was not valid."
+            case .transcriptionFailed(let message):
+                return message
+            }
+        }
+    }
+
+    private let apiKeyProvider: () -> String?
+    private let session: URLSession
+
+    init(apiKeyProvider: @escaping () -> String?, session: URLSession = .shared) {
+        self.apiKeyProvider = apiKeyProvider
+        self.session = session
+    }
+
+    func transcribe(audioURL: URL) async throws -> String {
+        guard let apiKey = apiKeyProvider() else {
+            throw ServiceError.missingAPIKey
+        }
+
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        let body = try buildBody(boundary: boundary, audioURL: audioURL)
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ServiceError.transcriptionFailed(message)
+        }
+
+        let transcription = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+        return transcription.text
+    }
+
+    private func buildBody(boundary: String, audioURL: URL) throws -> Data {
+        var data = Data()
+        let lineBreak = "\r\n"
+
+        data.append("--\(boundary)\(lineBreak)".data(using: .utf8)!)
+        data.append("Content-Disposition: form-data; name=\"model\"\(lineBreak + lineBreak)".data(using: .utf8)!)
+        data.append("gpt-4o-mini-transcribe\(lineBreak)".data(using: .utf8)!)
+
+        let audioData = try Data(contentsOf: audioURL)
+        data.append("--\(boundary)\(lineBreak)".data(using: .utf8)!)
+        data.append("Content-Disposition: form-data; name=\"file\"; filename=\"reminder.m4a\"\(lineBreak)".data(using: .utf8)!)
+        data.append("Content-Type: audio/mp4\(lineBreak + lineBreak)".data(using: .utf8)!)
+        data.append(audioData)
+        data.append(lineBreak.data(using: .utf8)!)
+
+        data.append("--\(boundary)--\(lineBreak)".data(using: .utf8)!)
+        return data
+    }
+}
+
+private struct TranscriptionResponse: Decodable {
+    let text: String
+}

--- a/ios/ReminderBoard/Sources/AppModule/RecordingViews.swift
+++ b/ios/ReminderBoard/Sources/AppModule/RecordingViews.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct RecordButton: View {
+    @EnvironmentObject private var captureCoordinator: ReminderCaptureCoordinator
+
+    var body: some View {
+        Button(action: toggleRecording) {
+            Label {
+                Text(captureCoordinator.state.buttonTitle)
+                    .font(.title2.weight(.semibold))
+                    .padding(.horizontal, 12)
+            } icon: {
+                Image(systemName: captureCoordinator.state.buttonIcon)
+                    .font(.title)
+            }
+            .padding(.vertical, 18)
+            .padding(.horizontal, 28)
+            .frame(maxWidth: .infinity)
+        }
+        .tint(.accentColor)
+        .buttonStyle(.borderedProminent)
+        .disabled(captureCoordinator.state == .uploading || captureCoordinator.state == .transcribing)
+        .accessibilityIdentifier("recordButton")
+    }
+
+    private func toggleRecording() {
+        Task { @MainActor in
+            switch captureCoordinator.state {
+            case .idle, .ready:
+                await captureCoordinator.startRecording()
+            case .recording:
+                await captureCoordinator.stopRecording()
+            case .transcribing, .uploading:
+                break
+            }
+        }
+    }
+}
+
+struct RecordingVisualization: View {
+    let state: ReminderCaptureCoordinator.State
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .strokeBorder(.secondary.opacity(0.3), lineWidth: 6)
+                    .frame(width: 160, height: 160)
+                Circle()
+                    .fill(state.visualColor.gradient)
+                    .frame(width: state.visualScale * 140, height: state.visualScale * 140)
+                    .animation(.easeInOut(duration: 0.3), value: state)
+                Image(systemName: state.visualIcon)
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundStyle(.white)
+                    .shadow(radius: 4)
+            }
+            Text(state.displayTitle)
+                .font(.title.weight(.bold))
+        }
+    }
+}
+
+#Preview("Idle") {
+    RecordingVisualization(state: .idle)
+}
+
+#Preview("Recording") {
+    RecordingVisualization(state: .recording)
+}
+
+#Preview("Uploading") {
+    RecordingVisualization(state: .uploading)
+}

--- a/ios/ReminderBoard/Sources/AppModule/ReminderBoardApp.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ReminderBoardApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@main
+struct ReminderBoardApp: App {
+    @StateObject private var captureCoordinator = ReminderCaptureCoordinator()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(captureCoordinator)
+                .task {
+                    await captureCoordinator.prepareAudioSession()
+                }
+        }
+        .defaultSize(width: 480, height: 640)
+    }
+}

--- a/ios/ReminderBoard/Sources/AppModule/ReminderCaptureCoordinator.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ReminderCaptureCoordinator.swift
@@ -1,0 +1,175 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ReminderCaptureCoordinator: NSObject, ObservableObject {
+    enum State: Equatable {
+        case idle
+        case ready
+        case recording
+        case transcribing
+        case uploading
+
+        var buttonTitle: String {
+            switch self {
+            case .idle, .ready:
+                return "Start Recording"
+            case .recording:
+                return "Stop Recording"
+            case .transcribing:
+                return "Transcribing…"
+            case .uploading:
+                return "Updating board…"
+            }
+        }
+
+        var buttonIcon: String {
+            switch self {
+            case .idle, .ready:
+                return "mic"
+            case .recording:
+                return "stop.circle"
+            case .transcribing:
+                return "waveform"
+            case .uploading:
+                return "arrow.up.circle"
+            }
+        }
+
+        var displayTitle: String {
+            switch self {
+            case .idle:
+                return "Ready"
+            case .ready:
+                return "Ready"
+            case .recording:
+                return "Recording"
+            case .transcribing:
+                return "Transcribing"
+            case .uploading:
+                return "Publishing"
+            }
+        }
+
+        var visualIcon: String {
+            switch self {
+            case .idle, .ready:
+                return "mic"
+            case .recording:
+                return "waveform"
+            case .transcribing:
+                return "ellipsis"
+            case .uploading:
+                return "icloud.and.arrow.up"
+            }
+        }
+
+        var visualColor: Color {
+            switch self {
+            case .idle, .ready:
+                return .blue
+            case .recording:
+                return .red
+            case .transcribing:
+                return .purple
+            case .uploading:
+                return .green
+            }
+        }
+
+        var visualScale: CGFloat {
+            switch self {
+            case .idle, .ready:
+                return 0.85
+            case .recording:
+                return 1.05
+            case .transcribing:
+                return 0.9
+            case .uploading:
+                return 0.95
+            }
+        }
+    }
+
+    @Published var state: State = .idle
+    @Published var statusMessage: String = "Call Siri and say “Capture reminder” to begin."
+    @Published var lastSuccessfulReminder: String?
+
+    private let recorder = VoiceReminderRecorder()
+    private let transcriptionService: OpenAITranscriptionService
+    private let reminderUploader: ReminderUploader
+
+    init(preview: Bool = false) {
+        if preview {
+            transcriptionService = OpenAITranscriptionService(apiKeyProvider: { "demo" })
+            reminderUploader = ReminderUploader(configuration: .preview)
+            statusMessage = "Preview ready"
+            lastSuccessfulReminder = "Buy milk and eggs on the way home."
+            state = .ready
+        } else {
+            transcriptionService = OpenAITranscriptionService(apiKeyProvider: {
+                Bundle.main.object(forInfoDictionaryKey: "OpenAIAPIKey") as? String
+            })
+            reminderUploader = ReminderUploader(configuration: .live)
+        }
+        super.init()
+
+    }
+
+    func prepareAudioSession() async {
+        do {
+            try recorder.prepare()
+            state = .ready
+            statusMessage = "Ready to capture reminders."
+        } catch {
+            state = .idle
+            statusMessage = "Microphone unavailable: \(error.localizedDescription)"
+        }
+    }
+
+    func bindToIntentNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleIntentTrigger), name: ReminderCaptureNotifications.beginCapture, object: nil)
+    }
+
+    func unbindFromIntentNotifications() {
+        NotificationCenter.default.removeObserver(self, name: ReminderCaptureNotifications.beginCapture, object: nil)
+    }
+
+    @objc
+    private func handleIntentTrigger() {
+        guard state == .ready || state == .idle else { return }
+        Task { await startRecording() }
+    }
+
+    func startRecording() async {
+        do {
+            try recorder.start()
+            state = .recording
+            statusMessage = "Listening…"
+        } catch {
+            state = .idle
+            statusMessage = "Recording failed: \(error.localizedDescription)"
+        }
+    }
+
+    func stopRecording() async {
+        guard case .recording = state else { return }
+        do {
+            let url = try recorder.stop()
+            state = .transcribing
+            statusMessage = "Sending audio to OpenAI…"
+            defer { try? FileManager.default.removeItem(at: url) }
+            let transcription = try await transcriptionService.transcribe(audioURL: url)
+            state = .uploading
+            statusMessage = "Updating display…"
+            try await reminderUploader.upload(reminder: transcription)
+            state = .ready
+            lastSuccessfulReminder = transcription
+            statusMessage = "Reminder published."
+        } catch {
+            state = .ready
+            statusMessage = "Could not publish reminder: \(error.localizedDescription)"
+        }
+    }
+
+}

--- a/ios/ReminderBoard/Sources/AppModule/ReminderCaptureIntent.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ReminderCaptureIntent.swift
@@ -1,0 +1,33 @@
+import AppIntents
+import Foundation
+
+struct CaptureReminderIntent: AppIntent {
+    static var title: LocalizedStringResource = "Capture reminder"
+    static var description = IntentDescription("Start recording a reminder for the wall display.")
+
+    static var openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        ReminderIntentBridge.shared.triggerCapture()
+        return .result(dialog: "Ready to record your reminder.")
+    }
+}
+
+struct ReminderAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(intent: CaptureReminderIntent(), phrases: [
+            "Capture reminder in \(.applicationName)",
+            "Remember this with \(.applicationName)",
+            "Add a reminder to the board using \(.applicationName)"
+        ])
+    }
+}
+
+@MainActor
+final class ReminderIntentBridge {
+    static let shared = ReminderIntentBridge()
+
+    func triggerCapture() {
+        NotificationCenter.default.post(name: ReminderCaptureNotifications.beginCapture, object: nil)
+    }
+}

--- a/ios/ReminderBoard/Sources/AppModule/ReminderCaptureNotifications.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ReminderCaptureNotifications.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum ReminderCaptureNotifications {
+    static let beginCapture = Notification.Name("com.example.reminderboard.beginCapture")
+}

--- a/ios/ReminderBoard/Sources/AppModule/ReminderUploader.swift
+++ b/ios/ReminderBoard/Sources/AppModule/ReminderUploader.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct ReminderUploader {
+    struct Configuration {
+        let baseURL: URL
+        let apiKey: String?
+
+        static let live = Configuration(
+            baseURL: URL(string: "http://192.168.1.50:8000")!,
+            apiKey: nil
+        )
+
+        static let preview = Configuration(
+            baseURL: URL(string: "http://localhost")!,
+            apiKey: nil
+        )
+    }
+
+    enum UploadError: LocalizedError {
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                return "The reminder service returned an unexpected response."
+            }
+        }
+    }
+
+    private let configuration: Configuration
+    private let session: URLSession
+
+    init(configuration: Configuration, session: URLSession = .shared) {
+        self.configuration = configuration
+        self.session = session
+    }
+
+    func upload(reminder: String) async throws {
+        var request = URLRequest(url: configuration.baseURL.appendingPathComponent("reminders"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let apiKey = configuration.apiKey {
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
+
+        let payload = ReminderPayload(text: reminder, createdAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        request.httpBody = try encoder.encode(payload)
+
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, 200..<300 ~= httpResponse.statusCode else {
+            throw UploadError.invalidResponse
+        }
+    }
+}
+
+private struct ReminderPayload: Encodable {
+    let text: String
+    let createdAt: Date
+}

--- a/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.231",
+          "green" : "0.403",
+          "red" : "0.137"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024",
+      "filename" : "AppIcon.png",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/Contents.json
+++ b/ios/ReminderBoard/Sources/AppModule/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/ReminderBoard/Sources/AppModule/VoiceReminderRecorder.swift
+++ b/ios/ReminderBoard/Sources/AppModule/VoiceReminderRecorder.swift
@@ -1,0 +1,76 @@
+import AVFoundation
+import Foundation
+
+@MainActor
+final class VoiceReminderRecorder {
+    enum State {
+        case idle
+        case recording
+    }
+
+    private(set) var state: State = .idle
+
+    private let engine = AVAudioEngine()
+    private var audioFileURL: URL?
+
+    func prepare() throws {
+        try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .spokenAudio, options: [.duckOthers])
+        try AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    func start() throws {
+        guard state == .idle else { return }
+
+        let format = engine.inputNode.outputFormat(forBus: 0)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("m4a")
+
+        let file = try AVAudioFile(forWriting: tempURL, settings: format.settings)
+
+        engine.inputNode.removeTap(onBus: 0)
+        engine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+            do {
+                try file.write(from: buffer)
+            } catch {
+                print("Audio write error: \(error)")
+            }
+        }
+
+        engine.prepare()
+        try engine.start()
+
+        state = .recording
+        audioFileURL = tempURL
+    }
+
+    func stop() throws -> URL {
+        guard state == .recording else {
+            throw RecorderError.notRecording
+        }
+
+        engine.stop()
+        engine.inputNode.removeTap(onBus: 0)
+        state = .idle
+
+        guard let url = audioFileURL else {
+            throw RecorderError.missingFile
+        }
+
+        return url
+    }
+
+    enum RecorderError: LocalizedError {
+        case notRecording
+        case missingFile
+
+        var errorDescription: String? {
+            switch self {
+            case .notRecording:
+                return "The recorder is not currently running."
+            case .missingFile:
+                return "No audio file was created."
+            }
+        }
+    }
+}

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from .storage import Reminder, ReminderStore
+
+app = FastAPI(title="Reminder Board Service")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+STORE = ReminderStore(Path(__file__).resolve().parent / "data" / "reminders.json")
+
+
+class ReminderCreate(BaseModel):
+    text: str = Field(..., min_length=1, max_length=280)
+    created_at: dt.datetime = Field(default_factory=lambda: dt.datetime.now(dt.timezone.utc))
+
+    def to_model(self) -> Reminder:
+        return Reminder(text=self.text.strip(), created_at=self.created_at.astimezone(dt.timezone.utc).isoformat())
+
+
+class ReminderResponse(BaseModel):
+    text: str
+    created_at: dt.datetime
+
+    @classmethod
+    def from_model(cls, reminder: Reminder) -> "ReminderResponse":
+        created = reminder.created_at.replace("Z", "+00:00")
+        return cls(text=reminder.text, created_at=dt.datetime.fromisoformat(created))
+
+
+def verify_api_key(x_api_key: Annotated[str | None, Header()] = None) -> None:
+    expected = (Path(__file__).resolve().parent / "API_KEY.txt")
+    if expected.exists():
+        token = expected.read_text(encoding="utf-8").strip()
+        if token and token != (x_api_key or ""):
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+@app.get("/reminders", response_model=list[ReminderResponse])
+def list_reminders() -> list[ReminderResponse]:
+    reminders = STORE.list()
+    return [ReminderResponse.from_model(item) for item in reminders]
+
+
+@app.post("/reminders", status_code=201)
+def create_reminder(payload: ReminderCreate, _: Annotated[None, Depends(verify_api_key)]) -> Response:
+    reminder = payload.to_model()
+    STORE.add(reminder)
+    return Response(status_code=201)
+
+
+@app.get("/", response_class=HTMLResponse)
+def render_board() -> str:
+    html_path = Path(__file__).resolve().parent / "static" / "index.html"
+    return html_path.read_text(encoding="utf-8")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Reminder Board</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "SF Pro Display", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+      body {
+        margin: 0;
+        background: #000;
+        color: #fff;
+        display: flex;
+        min-height: 100vh;
+        justify-content: center;
+        align-items: center;
+      }
+      main {
+        text-align: center;
+        max-width: 90vw;
+      }
+      h1 {
+        font-size: clamp(3rem, 8vw, 6rem);
+        margin-bottom: 2rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      li {
+        font-size: clamp(2rem, 6vw, 4.5rem);
+        margin-bottom: 1.8rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      li time {
+        display: block;
+        font-size: clamp(1rem, 2vw, 1.4rem);
+        opacity: 0.6;
+        margin-top: 0.6rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Reminder Board</h1>
+      <ul id="reminder-list"></ul>
+    </main>
+    <script>
+      const endpoint = new URL('/reminders', window.location.origin);
+      async function fetchReminders() {
+        try {
+          const response = await fetch(endpoint.toString());
+          if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+          }
+          const reminders = await response.json();
+          renderReminders(reminders);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      function renderReminders(reminders) {
+        const list = document.getElementById('reminder-list');
+        list.innerHTML = '';
+        if (!reminders.length) {
+          const empty = document.createElement('li');
+          empty.textContent = 'No reminders yet';
+          list.appendChild(empty);
+          return;
+        }
+        reminders.slice().reverse().forEach((reminder) => {
+          const item = document.createElement('li');
+          item.textContent = reminder.text;
+          const timestamp = document.createElement('time');
+          const createdAt = new Date(reminder.created_at);
+          timestamp.textContent = createdAt.toLocaleString([], {
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+          item.appendChild(timestamp);
+          list.appendChild(item);
+        });
+      }
+
+      fetchReminders();
+      setInterval(fetchReminders, 30000);
+    </script>
+  </body>
+</html>

--- a/server/storage.py
+++ b/server/storage.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import Lock
+from typing import List
+
+
+@dataclass
+class Reminder:
+    text: str
+    created_at: str
+
+
+class ReminderStore:
+    def __init__(self, path: Path, max_items: int = 32) -> None:
+        self._path = path
+        self._max_items = max_items
+        self._lock = Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            self._path.write_text("[]", encoding="utf-8")
+
+    def add(self, reminder: Reminder) -> None:
+        with self._lock:
+            reminders = self._load_all()
+            reminders.append(reminder)
+            reminders = reminders[-self._max_items :]
+            data = [asdict(item) for item in reminders]
+            self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def list(self) -> List[Reminder]:
+        with self._lock:
+            return self._load_all()
+
+    def _load_all(self) -> List[Reminder]:
+        if not self._path.exists():
+            return []
+        raw = json.loads(self._path.read_text(encoding="utf-8"))
+        reminders: List[Reminder] = [Reminder(**item) for item in raw]
+        return reminders


### PR DESCRIPTION
## Summary
- add a SwiftUI iOS application with Siri shortcut support to record reminders, transcribe them via OpenAI, and push updates to a wall display
- implement supporting services for audio capture, transcription, and server communication with configuration hooks for API keys and endpoints
- introduce a FastAPI backend with JSON persistence and a minimalist high-contrast web page optimized for an always-on iPad display

## Testing
- python -m compileall server

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6f84582c8324aae571009ad8a498)