### PR TITLE
Add reading list capture and desktop integration

### DIFF
--- a/CarPlayExtension/CarPlaySceneDelegate.swift
+++ b/CarPlayExtension/CarPlaySceneDelegate.swift
@@ -1,0 +1,27 @@
+import CarPlay
+import Combine
+
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+    private var interfaceController: CPInterfaceController?
+    private var viewModel: CarPlayVoiceController?
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController, to window: CPWindow) {
+        self.interfaceController = interfaceController
+        let voiceController = CarPlayVoiceController()
+        voiceController.delegate = self
+        viewModel = voiceController
+
+        interfaceController.setRootTemplate(voiceController.makeTemplate(), animated: true)
+    }
+
+    func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnect interfaceController: CPInterfaceController, from window: CPWindow) {
+        self.interfaceController = nil
+        viewModel = nil
+    }
+}
+
+extension CarPlaySceneDelegate: CarPlayVoiceControllerDelegate {
+    func carPlayVoiceControllerRequestsDismissal(_ controller: CarPlayVoiceController) {
+        interfaceController?.popTemplate(animated: true)
+    }
+}

--- a/CarPlayExtension/CarPlayVoiceController.swift
+++ b/CarPlayExtension/CarPlayVoiceController.swift
@@ -1,0 +1,55 @@
+import CarPlay
+import Combine
+import Speech
+import Foundation
+
+protocol CarPlayVoiceControllerDelegate: AnyObject {
+    func carPlayVoiceControllerRequestsDismissal(_ controller: CarPlayVoiceController)
+}
+
+final class CarPlayVoiceController: NSObject {
+    weak var delegate: CarPlayVoiceControllerDelegate?
+
+    private let speechService: SpeechCaptureServicing
+    private let syncCoordinator: SyncCoordinating
+    private var cancellables = Set<AnyCancellable>()
+
+    override init() {
+        let repository = TaskRepository()
+        let readingRepository = ReadingListRepository()
+        let deskSyncService = DailyDeskSyncService(readingRepository: readingRepository)
+        let syncCoordinator = SyncCoordinator(
+            repository: repository,
+            openAIService: OpenAIService(),
+            deskSyncService: deskSyncService,
+            readingListRepository: readingRepository
+        )
+        self.speechService = SpeechCaptureService()
+        self.syncCoordinator = syncCoordinator
+        super.init()
+        syncCoordinator.initialize()
+        bind()
+    }
+
+    func makeTemplate() -> CPTemplate {
+        let listeningState = CPVoiceControlState(identifier: "listen", titleVariants: ["Listening"], image: nil, repeats: false)
+        let template = CPVoiceControlTemplate(voiceControlStates: [listeningState])
+        template.startHandler = { [weak self] _ in
+            self?.speechService.startRecording()
+        }
+        template.stopHandler = { [weak self] _ in
+            guard let self else { return }
+            self.speechService.stopRecording()
+            self.delegate?.carPlayVoiceControllerRequestsDismissal(self)
+        }
+        return template
+    }
+
+    private func bind() {
+        speechService.capturedTaskPublisher
+            .sink { [weak self] task in
+                self?.syncCoordinator.enqueue(task: task)
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Configuration/IntegrationNotes.md
+++ b/Configuration/IntegrationNotes.md
@@ -1,0 +1,19 @@
+# Integration Notes
+
+This repository includes Swift source files for an iOS + CarPlay application (`VoiceTaskAssistant`) and a macOS companion app (`DeskCompanion`).
+
+To assemble the project in Xcode:
+
+1. Create a new *App* project with SwiftUI lifecycle named **VoiceTaskAssistant**.
+2. Add an App Group capability (e.g. `group.com.example.voicetaskassistant`) to both the iOS target and the macOS companion target.
+3. Enable the following capabilities for the iOS target:
+   - Background Modes: Audio, Voice over IP, Background fetch, Remote notifications.
+   - Siri.
+   - CarPlay Audio or CarPlay Navigation (for voice-first template usage).
+4. Add a CarPlay scene configuration with `CarPlaySceneDelegate` as the scene delegate class.
+5. Include a Speech Recognition usage description (`NSSpeechRecognitionUsageDescription`) and Microphone usage description (`NSMicrophoneUsageDescription`) in the iOS Info.plist.
+6. Store the OpenAI API key securely (e.g. in the Keychain or encrypted config) and expose it at runtime through the `OpenAIAPIKey` Info.plist entry or another secure mechanism used by `OpenAIConfig`.
+7. For the macOS companion app, create a separate target and reuse the `DeskCompanion` sources. Set the app group identifier to match the iOS app so that both apps share the `dailySummary.json` handoff file.
+8. Optionally configure background tasks to trigger morning desk sync even when the iOS app is suspended.
+
+The `DailyDeskSyncService` writes the processed structured tasks to a JSON file each morning so that the desktop companion can render the planned day without manual refresh.

--- a/Configuration/OpenAIConfig.swift
+++ b/Configuration/OpenAIConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct OpenAIConfig {
+    static var apiKey: String {
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "OpenAIAPIKey") as? String, !key.isEmpty else {
+            assertionFailure("Missing OpenAI API key. Add OpenAIAPIKey to Info.plist or use secure storage.")
+            return ""
+        }
+        return key
+    }
+
+    static let baseURL = URL(string: "https://api.openai.com/v1")!
+}

--- a/DeskCompanion/DeskCompanionApp.swift
+++ b/DeskCompanion/DeskCompanionApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct DeskCompanionApp: App {
+    @StateObject private var viewModel = DeskCompanionViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            DeskCompanionContentView(viewModel: viewModel)
+                .frame(minWidth: 420, minHeight: 480)
+        }
+    }
+}

--- a/DeskCompanion/DeskCompanionContentView.swift
+++ b/DeskCompanion/DeskCompanionContentView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+
+struct DeskCompanionContentView: View {
+    @ObservedObject var viewModel: DeskCompanionViewModel
+    @State private var newTitle: String = ""
+    @State private var newURL: String = ""
+    @State private var newTags: String = ""
+    @State private var selectedTags: Set<String> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Today's plan")
+                    .font(.largeTitle.weight(.semibold))
+                Spacer()
+                Button("Refresh") {
+                    viewModel.refresh()
+                }
+            }
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    if viewModel.tasks.isEmpty {
+                        VStack(spacing: 12) {
+                            ProgressView()
+                            Text("Waiting for today's sync…")
+                                .font(.headline)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 40)
+                    } else {
+                        ForEach(viewModel.tasks) { task in
+                            TaskCard(task: task)
+                        }
+                    }
+
+                    ReadingDashboard(
+                        sections: viewModel.readingSections,
+                        suggestedTags: viewModel.suggestedTags,
+                        errorMessage: viewModel.readingListError,
+                        newTitle: $newTitle,
+                        newURL: $newURL,
+                        newTags: $newTags,
+                        selectedTags: $selectedTags,
+                        addAction: addArticle
+                    )
+                }
+                .padding(.vertical, 8)
+            }
+        }
+        .padding(24)
+        .task {
+            await viewModel.loadDailySummary()
+            await viewModel.loadReadingList()
+        }
+    }
+
+    private func addArticle() {
+        let manualTags = newTags
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        viewModel.addArticle(
+            title: newTitle,
+            url: newURL,
+            tags: Array(selectedTags) + manualTags
+        )
+        if viewModel.readingListError == nil {
+            newTitle = ""
+            newURL = ""
+            newTags = ""
+            selectedTags.removeAll()
+        }
+    }
+}
+
+private struct TaskCard: View {
+    var task: DailySummary.TaskEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(task.summary)
+                .font(.title2.weight(.medium))
+            Text("Captured at " + task.capturedAt.formatted(date: .omitted, time: .shortened))
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if !task.topics.isEmpty {
+                Text(task.topics.map { $0.capitalized }.joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if !task.subtasks.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Subtasks")
+                        .font(.headline)
+                    ForEach(task.subtasks) { subtask in
+                        HStack {
+                            Image(systemName: "circle")
+                            Text(subtask.title)
+                            if let due = subtask.dueDate {
+                                Spacer()
+                                Text(due, style: .date)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !task.reminders.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Reminders")
+                        .font(.headline)
+                    ForEach(task.reminders) { reminder in
+                        Text("\(reminder.title) – \(reminder.fireDate.formatted(date: .omitted, time: .shortened))")
+                            .font(.callout)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .cornerRadius(16)
+    }
+}
+
+private struct ReadingDashboard: View {
+    var sections: [ReadingSection]
+    var suggestedTags: [String]
+    var errorMessage: String?
+    @Binding var newTitle: String
+    @Binding var newURL: String
+    @Binding var newTags: String
+    @Binding var selectedTags: Set<String>
+    var addAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Reading list")
+                .font(.title2.weight(.semibold))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .font(.footnote)
+            }
+
+            if sections.isEmpty {
+                Text("Add articles you want to read and they’ll be sorted by topic tags.")
+                    .foregroundColor(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(sections) { section in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(section.title)
+                                .font(.headline)
+                            ForEach(section.items) { item in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(item.title)
+                                        .font(.body)
+                                    Text(item.url.absoluteString)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                    if !item.tags.isEmpty {
+                                        Text(item.tags.map { $0.capitalized }.joined(separator: ", "))
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                                .padding()
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(12)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Add article")
+                    .font(.headline)
+
+                TextField("Title", text: $newTitle)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Link", text: $newURL)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Custom tags (comma separated)", text: $newTags)
+                    .textFieldStyle(.roundedBorder)
+
+                if !suggestedTags.isEmpty {
+                    TagSelectionView(tags: suggestedTags, selectedTags: $selectedTags)
+                }
+
+                Button(action: addAction) {
+                    Label("Save to reading list", systemImage: "tray.and.arrow.down")
+                }
+                .disabled(newURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .cornerRadius(16)
+    }
+}
+
+private struct TagSelectionView: View {
+    var tags: [String]
+    @Binding var selectedTags: Set<String>
+
+    private let columns = [GridItem(.adaptive(minimum: 100), spacing: 8)]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+            ForEach(tags, id: \.self) { tag in
+                let isSelected = selectedTags.contains(tag)
+                Text(tag.capitalized)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 10)
+                    .background(isSelected ? Color.accentColor.opacity(0.2) : Color.gray.opacity(0.1))
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1)
+                    )
+                    .onTapGesture {
+                        if isSelected {
+                            selectedTags.remove(tag)
+                        } else {
+                            selectedTags.insert(tag)
+                        }
+                    }
+            }
+        }
+    }
+}

--- a/DeskCompanion/DeskCompanionViewModel.swift
+++ b/DeskCompanion/DeskCompanionViewModel.swift
@@ -1,0 +1,138 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class DeskCompanionViewModel: ObservableObject {
+    @Published private(set) var tasks: [DailySummary.TaskEntry] = []
+    @Published private(set) var readingSections: [ReadingSection] = []
+    @Published private(set) var suggestedTags: [String] = []
+    @Published private(set) var readingListError: String?
+
+    private let reader = DailySummaryReader()
+    private let readingClient = ReadingListClient()
+
+    func loadDailySummary() async {
+        do {
+            let summary = try await reader.readSummary()
+            tasks = summary.tasks
+            suggestedTags = extractTags(from: summary.tasks)
+            readingSections = Self.groupReadingItems(summary.readingList.map { $0.asReadingItem() })
+        } catch {
+            tasks = []
+            readingSections = []
+            suggestedTags = []
+        }
+    }
+
+    func refresh() {
+        Task {
+            await loadDailySummary()
+            await loadReadingList()
+        }
+    }
+
+    func loadReadingList() async {
+        do {
+            let items = try readingClient.loadItems()
+            readingSections = Self.groupReadingItems(items)
+            readingListError = nil
+        } catch {
+            readingListError = "Unable to load reading list."
+        }
+    }
+
+    func addArticle(title: String, url: String, tags: [String]) {
+        do {
+            _ = try readingClient.addArticle(title: title, urlString: url, tags: tags)
+            readingListError = nil
+            Task { await loadReadingList() }
+        } catch {
+            readingListError = "Could not save article. Check the link."
+        }
+    }
+
+    private func extractTags(from tasks: [DailySummary.TaskEntry]) -> [String] {
+        Array(
+            Set(
+                tasks
+                    .flatMap { $0.topics }
+                    .map { $0.lowercased() }
+            )
+        ).sorted()
+    }
+
+    private static func groupReadingItems(_ items: [ReadingItem]) -> [ReadingSection] {
+        var grouped: [String: [ReadingItem]] = [:]
+        var untagged: [ReadingItem] = []
+
+        for item in items {
+            if item.tags.isEmpty {
+                untagged.append(item)
+            } else {
+                for tag in item.tags {
+                    grouped[tag, default: []].append(item)
+                }
+            }
+        }
+
+        let sections = grouped
+            .map { key, value in
+                ReadingSection(id: key, title: key.capitalized, items: value.sorted(by: { $0.capturedAt > $1.capturedAt }))
+            }
+            .sorted(by: { $0.title < $1.title })
+
+        var allSections = sections
+        if !untagged.isEmpty {
+            allSections.append(
+                ReadingSection(
+                    id: "untagged",
+                    title: "Untagged",
+                    items: untagged.sorted(by: { $0.capturedAt > $1.capturedAt })
+                )
+            )
+        }
+        return allSections
+    }
+}
+
+struct DailySummaryReader {
+    private let appGroupIdentifier = "group.com.example.voicetaskassistant"
+
+    func readSummary() async throws -> DailySummary {
+        let url = try await summaryURL()
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(DailySummary.self, from: data)
+    }
+
+    private func summaryURL() async throws -> URL {
+        #if os(macOS)
+        if let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) {
+            return containerURL.appendingPathComponent("dailySummary.json")
+        }
+        #endif
+        let fallback = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("dailySummary.json")
+        if !FileManager.default.fileExists(atPath: fallback.path) {
+            FileManager.default.createFile(atPath: fallback.path, contents: nil)
+        }
+        return fallback
+    }
+}
+
+struct ReadingSection: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let items: [ReadingItem]
+}
+
+private extension DailySummary.ReadingEntry {
+    func asReadingItem() -> ReadingItem {
+        ReadingItem(
+            id: id,
+            title: title,
+            url: url,
+            tags: tags,
+            capturedAt: capturedAt,
+            source: source
+        )
+    }
+}

--- a/DeskCompanion/ReadingListClient.swift
+++ b/DeskCompanion/ReadingListClient.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct ReadingListClient {
+    private let appGroupIdentifier = "group.com.example.voicetaskassistant"
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func loadItems() throws -> [ReadingItem] {
+        let url = try storageURL()
+        guard let data = try? Data(contentsOf: url), !data.isEmpty else { return [] }
+        let decoded = try JSONDecoder().decode([ReadingItem].self, from: data)
+        return decoded.sorted(by: { $0.capturedAt > $1.capturedAt })
+    }
+
+    func addArticle(title: String, urlString: String, tags: [String]) throws -> ReadingItem {
+        guard let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)),
+              !url.absoluteString.isEmpty else {
+            throw URLError(.badURL)
+        }
+
+        var items = (try? loadItems()) ?? []
+        let normalizedTags = normalize(tags: tags)
+        let newItem = ReadingItem(
+            title: title.isEmpty ? url.absoluteString : title,
+            url: url,
+            tags: normalizedTags,
+            capturedAt: Date(),
+            source: .companion
+        )
+
+        if let index = items.firstIndex(where: { $0.url == newItem.url }) {
+            var existing = items[index]
+            if !title.isEmpty { existing.title = title }
+            existing.tags = Array(Set(existing.tags + normalizedTags)).sorted()
+            existing.capturedAt = Date()
+            existing.source = .companion
+            items[index] = existing
+        } else {
+            items.append(newItem)
+        }
+
+        try persist(items: items)
+        return newItem
+    }
+
+    private func storageURL() throws -> URL {
+        #if os(macOS)
+        if let containerURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) {
+            let fileURL = containerURL.appendingPathComponent("readingList.json")
+            if !fileManager.fileExists(atPath: fileURL.path) {
+                fileManager.createFile(atPath: fileURL.path, contents: nil)
+            }
+            return fileURL
+        }
+        #endif
+        let fallback = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("readingList.json")
+        if !fileManager.fileExists(atPath: fallback.path) {
+            fileManager.createFile(atPath: fallback.path, contents: nil)
+        }
+        return fallback
+    }
+
+    private func persist(items: [ReadingItem]) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let sorted = items.sorted(by: { $0.capturedAt > $1.capturedAt })
+        let data = try encoder.encode(sorted)
+        try data.write(to: try storageURL(), options: [.atomic])
+    }
+
+    private func normalize(tags: [String]) -> [String] {
+        Array(
+            Set(
+                tags.map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .filter { !$0.isEmpty }
+            )
+        ).sorted()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# articles
+# Voice Task Assistant
+
+A native iOS and CarPlay experience powered by the OpenAI API for voice-first task capture and daily planning, accompanied by a macOS desk companion.
+
+## Features
+
+- **Instant voice capture** using the iOS Speech framework and AVAudioEngine for zero-delay transcription.
+- **Offline-first storage** of captured tasks so nothing is lost when the device is offline.
+- **Automated OpenAI processing** that turns captured speech into structured to-dos with subtasks, reminders, topical tags, and recommended reading links.
+- **CarPlay voice interface** for hands-free task capture while driving.
+- **Minimal, single-action UI** optimized for rapid input.
+- **Daily desk sync** via an App Group JSON handoff consumed by the macOS companion app.
+- **Cross-device reading list** that captures article mentions from voice notes, syncs them with the desktop companion, and lets you add links manually with smart tag suggestions.
+
+## Project structure
+
+```
+VoiceTaskAssistant/
+  VoiceTaskAssistantApp.swift        // iOS SwiftUI entry point
+  ContentView.swift                  // Minimal capture UI
+  Models/                            // CapturedTask & StructuredTask definitions
+    ReadingItem.swift                // Shared reading list item model
+  Services/                          // Speech capture, persistence, OpenAI integration, sync orchestration
+    ReadingListRepository.swift      // Offline-first reading list persistence
+  ViewModel/                         // TaskCaptureViewModel bridging UI and services
+CarPlayExtension/
+  CarPlaySceneDelegate.swift         // Scene bridge into CarPlay
+  CarPlayVoiceController.swift       // Voice-only CarPlay experience
+DeskCompanion/
+  DeskCompanionApp.swift             // macOS SwiftUI entry point
+  DeskCompanionContentView.swift     // Daily planning UI
+  DeskCompanionViewModel.swift       // Reads shared summaries and reading list
+  ReadingListClient.swift            // macOS helper for shared reading list mutations
+Configuration/
+  OpenAIConfig.swift                 // API configuration helper
+  IntegrationNotes.md                // Xcode integration checklist
+```
+
+## OpenAI usage
+
+`OpenAIService` posts captured utterances to the `responses` endpoint with the `gpt-4.1-mini` model and expects a JSON payload describing the structured plan, related topic tags, and any article references (title, URL, tags). The response is saved to local storage, feeds the reading list, and is included in the daily summary exported for the desktop companion.
+
+## Building in Xcode
+
+Use the guidance in `Configuration/IntegrationNotes.md` to wire the targets, entitlements, and Info.plist keys. The project assumes an App Group identifier of `group.com.example.voicetaskassistant`; update the string where necessary to match your team identifier.

--- a/VoiceTaskAssistant/ContentView.swift
+++ b/VoiceTaskAssistant/ContentView.swift
@@ -1,0 +1,329 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: TaskCaptureViewModel
+    @State private var showingAddArticle = false
+
+    var body: some View {
+        ZStack {
+            Color(.systemBackground)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                VStack(spacing: 8) {
+                    Text(viewModel.transcriptionText.isEmpty ? "Tap to capture" : viewModel.transcriptionText)
+                        .font(.title2)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(16)
+
+                    if let status = viewModel.captureStatusMessage {
+                        Text(status)
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                CaptureButton(isRecording: viewModel.isRecording) {
+                    viewModel.toggleCapture()
+                }
+                .accessibilityLabel(viewModel.isRecording ? "Stop recording" : "Start recording")
+
+                if !viewModel.pendingTasks.isEmpty {
+                    PendingTaskList(tasks: viewModel.pendingTasks)
+                        .transition(.move(edge: .bottom))
+                }
+
+                ReadingListPanel(
+                    sections: viewModel.readingSections,
+                    suggestedTags: viewModel.suggestedTags,
+                    errorMessage: viewModel.readingListError,
+                    addAction: { showingAddArticle = true }
+                )
+            }
+            .padding(32)
+        }
+        .onAppear {
+            viewModel.startup()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            viewModel.resume()
+        }
+        .sheet(isPresented: $showingAddArticle) {
+            AddArticleSheet()
+                .environmentObject(viewModel)
+        }
+    }
+}
+
+private struct CaptureButton: View {
+    var isRecording: Bool
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(isRecording ? Color.red : Color.accentColor)
+                    .frame(width: 120, height: 120)
+                    .shadow(color: .black.opacity(0.2), radius: 12, x: 0, y: 6)
+
+                Image(systemName: isRecording ? "stop.fill" : "mic.fill")
+                    .font(.system(size: 44))
+                    .foregroundColor(.white)
+            }
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+private struct PendingTaskList: View {
+    var tasks: [CapturedTask]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Captured tasks")
+                .font(.headline)
+
+            ForEach(tasks) { task in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(task.rawText)
+                        .font(.body)
+                    Text(task.timestamp.formatted(date: .omitted, time: .shortened))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color(.tertiarySystemBackground))
+                .cornerRadius(12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct ReadingListPanel: View {
+    var sections: [ReadingListSection]
+    var suggestedTags: [String]
+    var errorMessage: String?
+    var addAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Reading list")
+                    .font(.headline)
+                Spacer()
+                Button(action: addAction) {
+                    Label("Add article", systemImage: "plus")
+                }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundColor(.red)
+            }
+
+            if sections.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Save links to dig into later.")
+                        .foregroundColor(.secondary)
+                    if !suggestedTags.isEmpty {
+                        TagSuggestionsView(tags: suggestedTags)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(Color(.tertiarySystemBackground))
+                .cornerRadius(12)
+            } else {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(sections) { section in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(section.title)
+                                .font(.subheadline.weight(.semibold))
+                                .textCase(.uppercase)
+
+                            ForEach(section.items) { item in
+                                ReadingItemRow(item: item)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct TagSuggestionsView: View {
+    var tags: [String]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(tags, id: \.self) { tag in
+                    Text(tag.capitalized)
+                        .font(.caption)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 8)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+                }
+            }
+        }
+    }
+}
+
+private struct ReadingItemRow: View {
+    var item: ReadingItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.title)
+                .font(.body)
+            Link(destination: item.url) {
+                Text(item.url.absoluteString)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            if !item.tags.isEmpty {
+                Text(item.tags.map { $0.capitalized }.joined(separator: ", "))
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.tertiarySystemBackground))
+        .cornerRadius(12)
+    }
+}
+
+private struct AddArticleSheet: View {
+    @EnvironmentObject private var viewModel: TaskCaptureViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var url: String = ""
+    @State private var tagsInput: String = ""
+    @State private var selectedTags: Set<String> = []
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Article") {
+                    TextField("Title", text: $title)
+                    TextField("Link", text: $url)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                }
+
+                if !viewModel.suggestedTags.isEmpty {
+                    Section("Suggested tags") {
+                        FlexibleTagSelector(
+                            tags: viewModel.suggestedTags,
+                            selectedTags: $selectedTags
+                        )
+                    }
+                }
+
+                Section("Custom tags") {
+                    TextField("Comma separated", text: $tagsInput)
+                }
+
+                if let error = viewModel.readingListError {
+                    Section {
+                        Text(error)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("Add article")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") {
+                            Task { await save() }
+                        }
+                        .disabled(url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+            .onAppear {
+                title = ""
+                url = ""
+                tagsInput = ""
+                selectedTags.removeAll()
+                viewModel.clearReadingListError()
+            }
+        }
+    }
+
+    private func save() async {
+        guard !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+        let manualTags = tagsInput
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        let success = await viewModel.addArticle(
+            title: title,
+            urlString: url,
+            tags: Array(selectedTags) + manualTags
+        )
+        if success {
+            dismiss()
+        }
+    }
+}
+
+private struct FlexibleTagSelector: View {
+    var tags: [String]
+    @Binding var selectedTags: Set<String>
+
+    private let columns = [GridItem(.adaptive(minimum: 80), spacing: 8)]
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+            ForEach(tags, id: \.self) { tag in
+                let isSelected = selectedTags.contains(tag)
+                Text(tag.capitalized)
+                    .font(.caption)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 10)
+                    .background(isSelected ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+                    .cornerRadius(10)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 1)
+                    )
+                    .onTapGesture {
+                        if isSelected {
+                            selectedTags.remove(tag)
+                        } else {
+                            selectedTags.insert(tag)
+                        }
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(TaskCaptureViewModel(
+            speechService: PreviewSpeechService(),
+            syncCoordinator: PreviewSyncCoordinator(),
+            readingListManager: PreviewReadingListManager()
+        ))
+}

--- a/VoiceTaskAssistant/Models/CapturedTask.swift
+++ b/VoiceTaskAssistant/Models/CapturedTask.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct CapturedTask: Identifiable, Codable, Hashable {
+    enum Status: String, Codable {
+        case pending
+        case syncing
+        case processed
+        case failed
+    }
+
+    struct Segment: Codable, Hashable {
+        let text: String
+        let timestamp: TimeInterval
+    }
+
+    let id: UUID
+    let rawText: String
+    let timestamp: Date
+    var status: Status
+    var structured: StructuredTask?
+    var segments: [Segment]
+
+    init(id: UUID = UUID(), rawText: String, timestamp: Date = .now, status: Status = .pending, structured: StructuredTask? = nil, segments: [Segment] = []) {
+        self.id = id
+        self.rawText = rawText
+        self.timestamp = timestamp
+        self.status = status
+        self.structured = structured
+        self.segments = segments
+    }
+}

--- a/VoiceTaskAssistant/Models/ReadingItem.swift
+++ b/VoiceTaskAssistant/Models/ReadingItem.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ReadingItem: Identifiable, Codable, Hashable, Sendable {
+    enum Source: String, Codable {
+        case manual
+        case task
+        case companion
+    }
+
+    let id: UUID
+    var title: String
+    var url: URL
+    var tags: [String]
+    var capturedAt: Date
+    var source: Source
+    var relatedTaskID: UUID?
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        url: URL,
+        tags: [String] = [],
+        capturedAt: Date = .now,
+        source: Source,
+        relatedTaskID: UUID? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.url = url
+        self.tags = tags
+        self.capturedAt = capturedAt
+        self.source = source
+        self.relatedTaskID = relatedTaskID
+    }
+}

--- a/VoiceTaskAssistant/Models/StructuredTask.swift
+++ b/VoiceTaskAssistant/Models/StructuredTask.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct StructuredTask: Codable, Hashable {
+    struct Subtask: Codable, Hashable, Identifiable {
+        let id: UUID
+        let title: String
+        let dueDate: Date?
+        let notes: String?
+
+        init(id: UUID = UUID(), title: String, dueDate: Date? = nil, notes: String? = nil) {
+            self.id = id
+            self.title = title
+            self.dueDate = dueDate
+            self.notes = notes
+        }
+    }
+
+    let summary: String
+    let subtasks: [Subtask]
+    let reminders: [Reminder]
+    let topics: [String]
+    let readingList: [ReadingReference]
+
+    init(summary: String, subtasks: [Subtask], reminders: [Reminder], topics: [String], readingList: [ReadingReference]) {
+        self.summary = summary
+        self.subtasks = subtasks
+        self.reminders = reminders
+        self.topics = topics
+        self.readingList = readingList
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        summary = try container.decode(String.self, forKey: .summary)
+        subtasks = try container.decodeIfPresent([Subtask].self, forKey: .subtasks) ?? []
+        reminders = try container.decodeIfPresent([Reminder].self, forKey: .reminders) ?? []
+        topics = try container.decodeIfPresent([String].self, forKey: .topics) ?? []
+        readingList = try container.decodeIfPresent([ReadingReference].self, forKey: .readingList) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(summary, forKey: .summary)
+        try container.encode(subtasks, forKey: .subtasks)
+        try container.encode(reminders, forKey: .reminders)
+        try container.encode(topics, forKey: .topics)
+        try container.encode(readingList, forKey: .readingList)
+    }
+
+    struct Reminder: Codable, Hashable, Identifiable {
+        let id: UUID
+        let title: String
+        let fireDate: Date
+
+        init(id: UUID = UUID(), title: String, fireDate: Date) {
+            self.id = id
+            self.title = title
+            self.fireDate = fireDate
+        }
+    }
+}
+
+extension StructuredTask {
+    struct ReadingReference: Codable, Hashable, Identifiable {
+        let id: UUID
+        let title: String
+        let url: URL
+        let tags: [String]
+
+        init(id: UUID = UUID(), title: String, url: URL, tags: [String]) {
+            self.id = id
+            self.title = title
+            self.url = url
+            self.tags = tags
+        }
+    }
+}

--- a/VoiceTaskAssistant/Services/DailyDeskSyncService.swift
+++ b/VoiceTaskAssistant/Services/DailyDeskSyncService.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+final class DailyDeskSyncService {
+    private let calendar: Calendar
+    private let fileManager: FileManager
+    private let appGroupIdentifier = "group.com.example.voicetaskassistant"
+    private var scheduledWork: DispatchWorkItem?
+    private let readingRepository: ReadingListManaging?
+
+    init(calendar: Calendar = .current, fileManager: FileManager = .default, readingRepository: ReadingListManaging? = nil) {
+        self.calendar = calendar
+        self.fileManager = fileManager
+        self.readingRepository = readingRepository
+    }
+
+    func record(task: CapturedTask) async {}
+
+    func publishDailySummary(tasks: [CapturedTask]) async {
+        guard let url = sharedFileURL() else { return }
+        let readingItems = await readingRepository?.loadItems() ?? []
+        let summary = DailySummary(date: Date(), tasks: tasks.compactMap { task in
+            guard let structured = task.structured else { return nil }
+            return DailySummary.TaskEntry(from: structured, capturedAt: task.timestamp)
+        }, readingList: readingItems.map(DailySummary.ReadingEntry.init(from:)))
+
+        do {
+            let data = try JSONEncoder().encode(summary)
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            print("Failed to write daily summary: \(error)")
+        }
+    }
+
+    func scheduleMorningSync(action: @escaping () -> Void) {
+        scheduledWork?.cancel()
+        let nextMorning = calendar.nextDate(after: Date(), matching: DateComponents(hour: 7, minute: 0), matchingPolicy: .nextTimePreservingSmallerComponents) ?? Date().addingTimeInterval(3600 * 24)
+        let delay = max(1, nextMorning.timeIntervalSinceNow)
+        let workItem = DispatchWorkItem(block: action)
+        scheduledWork = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func sharedFileURL() -> URL? {
+        #if os(iOS)
+        return fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?.appendingPathComponent("dailySummary.json")
+        #else
+        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("dailySummary.json")
+        #endif
+    }
+}
+
+struct DailySummary: Codable {
+    let date: Date
+    let tasks: [TaskEntry]
+    let readingList: [ReadingEntry]
+
+    struct TaskEntry: Codable, Identifiable {
+        let id: UUID
+        let summary: String
+        let subtasks: [StructuredTask.Subtask]
+        let reminders: [StructuredTask.Reminder]
+        let capturedAt: Date
+        let topics: [String]
+
+        init(from task: StructuredTask, capturedAt: Date) {
+            self.id = UUID()
+            self.summary = task.summary
+            self.subtasks = task.subtasks
+            self.reminders = task.reminders
+            self.capturedAt = capturedAt
+            self.topics = task.topics
+        }
+    }
+}
+
+extension DailySummary {
+    struct ReadingEntry: Codable, Identifiable {
+        let id: UUID
+        let title: String
+        let url: URL
+        let tags: [String]
+        let capturedAt: Date
+        let source: ReadingItem.Source
+
+        init(from item: ReadingItem) {
+            id = item.id
+            title = item.title
+            url = item.url
+            tags = item.tags
+            capturedAt = item.capturedAt
+            source = item.source
+        }
+    }
+}

--- a/VoiceTaskAssistant/Services/OpenAIService.swift
+++ b/VoiceTaskAssistant/Services/OpenAIService.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Combine
+
+protocol OpenAIProcessing {
+    func process(task: CapturedTask) async throws -> StructuredTask
+}
+
+struct OpenAIService: OpenAIProcessing {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func process(task: CapturedTask) async throws -> StructuredTask {
+        var request = URLRequest(url: OpenAIConfig.baseURL.appendingPathComponent("responses"))
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(OpenAIConfig.apiKey)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload = OpenAIRequest(task: task)
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+            throw OpenAIError.invalidResponse
+        }
+
+        let decoded = try JSONDecoder().decode(OpenAIResponse.self, from: data)
+        return decoded.toStructuredTask()
+    }
+}
+
+private struct OpenAIRequest: Encodable {
+    let model = "gpt-4.1-mini"
+    let input: [Message]
+
+    init(task: CapturedTask) {
+        let systemPrompt = """
+        You are a helpful assistant that rewrites spoken to-do list items into structured plans. Return strict JSON with these keys:
+        - summary: concise string describing the task
+        - subtasks: array of {id, title, dueDate, notes}
+        - reminders: array of {id, title, fireDate}
+        - topics: array of lowercase tag strings describing relevant themes
+        - readingList: array of {id, title, url, tags} capturing any article links the user mentioned or that would deepen understanding of the topics. Use empty arrays when nothing applies. Use ISO8601 dates.
+        """
+        let system = Message(role: "system", content: systemPrompt)
+        let user = Message(role: "user", content: "Task: \(task.rawText)")
+        input = [system, user]
+    }
+
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+}
+
+private struct OpenAIResponse: Decodable {
+    let output: [Choice]
+
+    struct Choice: Decodable {
+        let content: [OutputContent]
+    }
+
+    struct OutputContent: Decodable {
+        let text: String?
+    }
+
+    func toStructuredTask() throws -> StructuredTask {
+        guard let jsonString = output.first?.content.first?.text,
+              let data = jsonString.data(using: .utf8) else {
+            throw OpenAIError.invalidResponse
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(StructuredTask.self, from: data)
+    }
+}
+
+enum OpenAIError: Error {
+    case invalidResponse
+}

--- a/VoiceTaskAssistant/Services/ReadingListRepository.swift
+++ b/VoiceTaskAssistant/Services/ReadingListRepository.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Combine
+
+protocol ReadingListManaging: Sendable {
+    var readingItemsPublisher: AnyPublisher<[ReadingItem], Never> { get }
+    func loadItems() async -> [ReadingItem]
+    func upsert(item: ReadingItem) async throws
+    @discardableResult
+    func addManualArticle(title: String, urlString: String, tags: [String]) async throws -> ReadingItem
+}
+
+enum ReadingListError: Error {
+    case invalidURL
+}
+
+actor ReadingListRepository: ReadingListManaging {
+    private let fileURL: URL
+    private var cache: [ReadingItem] = []
+    private let fileManager: FileManager
+    nonisolated private let subject = CurrentValueSubject<[ReadingItem], Never>([])
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        #if os(iOS)
+        let directory = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.example.voicetaskassistant")
+            ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        #else
+        let directory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        #endif
+        fileURL = directory.appendingPathComponent("readingList.json")
+
+        if let data = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode([ReadingItem].self, from: data) {
+            cache = decoded
+        }
+        cache.sort(by: { $0.capturedAt > $1.capturedAt })
+        subject.send(cache)
+    }
+
+    nonisolated var readingItemsPublisher: AnyPublisher<[ReadingItem], Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    func loadItems() async -> [ReadingItem] {
+        if cache.isEmpty, let data = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode([ReadingItem].self, from: data) {
+            cache = decoded
+            cache.sort(by: { $0.capturedAt > $1.capturedAt })
+            subject.send(cache)
+        }
+        return cache
+    }
+
+    func upsert(item: ReadingItem) async throws {
+        var normalized = normalize(item: item)
+        if let index = cache.firstIndex(where: { $0.url == normalized.url }) {
+            var existing = cache[index]
+            existing.title = normalized.title.isEmpty ? existing.title : normalized.title
+            existing.tags = merge(existing.tags, with: normalized.tags)
+            existing.capturedAt = max(existing.capturedAt, normalized.capturedAt)
+            existing.source = normalized.source
+            existing.relatedTaskID = normalized.relatedTaskID ?? existing.relatedTaskID
+            cache[index] = existing
+        } else {
+            cache.append(normalized)
+        }
+        try persist()
+    }
+
+    @discardableResult
+    func addManualArticle(title: String, urlString: String, tags: [String]) async throws -> ReadingItem {
+        guard let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)),
+              !url.absoluteString.isEmpty else {
+            throw ReadingListError.invalidURL
+        }
+        let item = ReadingItem(
+            title: title.isEmpty ? url.absoluteString : title,
+            url: url,
+            tags: normalize(tags: tags),
+            capturedAt: Date(),
+            source: .manual,
+            relatedTaskID: nil
+        )
+        try await upsert(item: item)
+        return item
+    }
+
+    private func persist() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        cache = cache.sorted(by: { $0.capturedAt > $1.capturedAt })
+        let data = try encoder.encode(cache)
+        try data.write(to: fileURL, options: [.atomic])
+        subject.send(cache)
+    }
+
+    private func normalize(item: ReadingItem) -> ReadingItem {
+        var normalized = item
+        normalized.tags = normalize(tags: item.tags)
+        return normalized
+    }
+
+    private func normalize(tags: [String]) -> [String] {
+        Array(
+            Set(
+                tags
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .filter { !$0.isEmpty }
+            )
+        ).sorted()
+    }
+
+    private func merge(_ lhs: [String], with rhs: [String]) -> [String] {
+        Array(Set(lhs + rhs)).sorted()
+    }
+}

--- a/VoiceTaskAssistant/Services/SpeechCaptureService.swift
+++ b/VoiceTaskAssistant/Services/SpeechCaptureService.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Combine
+import Speech
+import AVFoundation
+
+struct SpeechTranscriptionUpdate {
+    let text: String
+    let isRecording: Bool
+    let statusMessage: String?
+}
+
+protocol SpeechCaptureServicing {
+    var transcriptionPublisher: AnyPublisher<SpeechTranscriptionUpdate, Never> { get }
+    var capturedTaskPublisher: AnyPublisher<CapturedTask, Never> { get }
+
+    func startRecording()
+    func stopRecording()
+}
+
+final class SpeechCaptureService: NSObject, SpeechCaptureServicing {
+    private let transcriptionSubject = PassthroughSubject<SpeechTranscriptionUpdate, Never>()
+    private let capturedTaskSubject = PassthroughSubject<CapturedTask, Never>()
+
+    private let audioEngine = AVAudioEngine()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let recognizer = SFSpeechRecognizer()
+    private var currentSegments: [CapturedTask.Segment] = []
+
+    var transcriptionPublisher: AnyPublisher<SpeechTranscriptionUpdate, Never> {
+        transcriptionSubject.eraseToAnyPublisher()
+    }
+
+    var capturedTaskPublisher: AnyPublisher<CapturedTask, Never> {
+        capturedTaskSubject.eraseToAnyPublisher()
+    }
+
+    func startRecording() {
+        Task { @MainActor in
+            guard await requestPermissions() else {
+                transcriptionSubject.send(SpeechTranscriptionUpdate(text: "", isRecording: false, statusMessage: "Speech permission denied"))
+                return
+            }
+
+            resetRecognition()
+
+            recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+            recognitionRequest?.shouldReportPartialResults = true
+
+            let inputNode = audioEngine.inputNode
+            let recordingFormat = inputNode.outputFormat(forBus: 0)
+            inputNode.removeTap(onBus: 0)
+            inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
+                self?.recognitionRequest?.append(buffer)
+            }
+
+            audioEngine.prepare()
+            try? audioEngine.start()
+
+            guard let recognitionRequest else { return }
+
+            recognitionTask = recognizer?.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+                guard let self else { return }
+                if let result {
+                    let finalText = result.bestTranscription.formattedString
+                    self.captureSegments(from: result.bestTranscription)
+                    self.transcriptionSubject.send(SpeechTranscriptionUpdate(text: finalText, isRecording: true, statusMessage: "Listening…"))
+                    if result.isFinal {
+                        self.finish(with: finalText)
+                    }
+                } else if let error {
+                    self.transcriptionSubject.send(SpeechTranscriptionUpdate(text: "", isRecording: false, statusMessage: "Error: \(error.localizedDescription)"))
+                }
+            }
+
+            transcriptionSubject.send(SpeechTranscriptionUpdate(text: "", isRecording: true, statusMessage: "Listening…"))
+        }
+    }
+
+    func stopRecording() {
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
+        recognitionTask?.finish()
+        let combinedText = currentSegments.map(\.text).joined(separator: " ")
+        transcriptionSubject.send(SpeechTranscriptionUpdate(text: combinedText, isRecording: false, statusMessage: "Processing…"))
+    }
+
+    private func finish(with text: String) {
+        audioEngine.stop()
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+
+        let task = CapturedTask(rawText: text, segments: currentSegments)
+        capturedTaskSubject.send(task)
+        transcriptionSubject.send(SpeechTranscriptionUpdate(text: text, isRecording: false, statusMessage: "Captured"))
+        currentSegments = []
+    }
+
+    private func resetRecognition() {
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        recognitionRequest = nil
+        currentSegments = []
+    }
+
+    private func captureSegments(from transcription: SFTranscription) {
+        currentSegments = transcription.segments.map { segment in
+            CapturedTask.Segment(text: segment.substring, timestamp: segment.timestamp)
+        }
+    }
+
+    private func requestPermissions() async -> Bool {
+        let speechStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+
+        let audioGranted = await withCheckedContinuation { continuation in
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+
+        return (speechStatus == .authorized) && audioGranted
+    }
+}

--- a/VoiceTaskAssistant/Services/SyncCoordinator.swift
+++ b/VoiceTaskAssistant/Services/SyncCoordinator.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Combine
+import Network
+
+protocol SyncCoordinating {
+    var processedTaskPublisher: AnyPublisher<CapturedTask, Never> { get }
+    var pendingTasksPublisher: AnyPublisher<[CapturedTask], Never> { get }
+
+    func initialize()
+    func enqueue(task: CapturedTask)
+    func loadCachedTasks() async -> [CapturedTask]
+}
+
+final class SyncCoordinator: SyncCoordinating {
+    private let repository: TaskRepository
+    private let openAIService: OpenAIProcessing
+    private let deskSyncService: DailyDeskSyncService
+    private let readingListRepository: ReadingListManaging
+    private let queue = DispatchQueue(label: "SyncCoordinator")
+    private var syncWorkItem: DispatchWorkItem?
+    private var monitor: NWPathMonitor?
+
+    private var cachedTasks: [CapturedTask] = []
+
+    private let processedTaskSubject = PassthroughSubject<CapturedTask, Never>()
+    private let pendingTasksSubject = CurrentValueSubject<[CapturedTask], Never>([])
+
+    init(repository: TaskRepository, openAIService: OpenAIProcessing, deskSyncService: DailyDeskSyncService, readingListRepository: ReadingListManaging) {
+        self.repository = repository
+        self.openAIService = openAIService
+        self.deskSyncService = deskSyncService
+        self.readingListRepository = readingListRepository
+    }
+
+    var processedTaskPublisher: AnyPublisher<CapturedTask, Never> {
+        processedTaskSubject.eraseToAnyPublisher()
+    }
+
+    var pendingTasksPublisher: AnyPublisher<[CapturedTask], Never> {
+        pendingTasksSubject.eraseToAnyPublisher()
+    }
+
+    func initialize() {
+        Task { @MainActor in
+            let tasks = await repository.loadTasks()
+            cachedTasks = tasks
+            pendingTasksSubject.send(tasks)
+            setUpNetworkMonitoring()
+            scheduleDailyDeskSync()
+        }
+    }
+
+    func enqueue(task: CapturedTask) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.cachedTasks.append(task)
+            self.pendingTasksSubject.send(self.cachedTasks)
+            Task {
+                try? await self.repository.save(task: task)
+                await self.attemptSync()
+            }
+        }
+    }
+
+    func loadCachedTasks() async -> [CapturedTask] {
+        await repository.loadTasks()
+    }
+
+    private func setUpNetworkMonitoring() {
+        monitor = NWPathMonitor()
+        monitor?.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            if path.status == .satisfied {
+                Task { await self.attemptSync() }
+            }
+        }
+        monitor?.start(queue: queue)
+    }
+
+    private func attemptSync() async {
+        let pending = cachedTasks.filter { $0.status == .pending || $0.status == .failed }
+        guard !pending.isEmpty else { return }
+
+        for var task in pending {
+            task.status = .syncing
+            await updateCached(task)
+            do {
+                let structured = try await openAIService.process(task: task)
+                task.status = .processed
+                task.structured = structured
+                await updateCached(task)
+                processedTaskSubject.send(task)
+                try await repository.update(task: task)
+                await deskSyncService.record(task: task)
+                await handleReadingReferences(for: task, structured: structured)
+            } catch {
+                task.status = .failed
+                await updateCached(task)
+                processedTaskSubject.send(task)
+                try? await repository.update(task: task)
+            }
+        }
+    }
+
+    private func handleReadingReferences(for task: CapturedTask, structured: StructuredTask) async {
+        for reference in structured.readingList {
+            let combinedTags = Array(Set(reference.tags + structured.topics)).sorted()
+            let item = ReadingItem(
+                title: reference.title,
+                url: reference.url,
+                tags: combinedTags,
+                capturedAt: Date(),
+                source: .task,
+                relatedTaskID: task.id
+            )
+            try? await readingListRepository.upsert(item: item)
+        }
+
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return }
+        let matches = detector.matches(
+            in: task.rawText,
+            options: [],
+            range: NSRange(location: 0, length: (task.rawText as NSString).length)
+        )
+        let referencedURLs = Set(structured.readingList.map { $0.url })
+        for match in matches {
+            guard let range = Range(match.range, in: task.rawText) else { continue }
+            let linkText = String(task.rawText[range])
+            guard let url = URL(string: linkText), !referencedURLs.contains(url) else { continue }
+            let item = ReadingItem(
+                title: structured.summary,
+                url: url,
+                tags: structured.topics,
+                capturedAt: Date(),
+                source: .task,
+                relatedTaskID: task.id
+            )
+            try? await readingListRepository.upsert(item: item)
+        }
+    }
+
+    private func updateCached(_ task: CapturedTask) async {
+        if let index = cachedTasks.firstIndex(where: { $0.id == task.id }) {
+            cachedTasks[index] = task
+        } else {
+            cachedTasks.append(task)
+        }
+        pendingTasksSubject.send(cachedTasks)
+    }
+
+    private func scheduleDailyDeskSync() {
+        deskSyncService.scheduleMorningSync {
+            Task { await self.performDeskSync() }
+        }
+    }
+
+    private func performDeskSync() async {
+        let processed = cachedTasks.filter { $0.status == .processed }
+        await deskSyncService.publishDailySummary(tasks: processed)
+    }
+}

--- a/VoiceTaskAssistant/Services/TaskRepository.swift
+++ b/VoiceTaskAssistant/Services/TaskRepository.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+protocol TaskPersisting {
+    func save(task: CapturedTask) async throws
+    func update(task: CapturedTask) async throws
+    func loadTasks() async -> [CapturedTask]
+}
+
+actor TaskRepository: TaskPersisting {
+    private let fileURL: URL
+    private var cache: [CapturedTask] = []
+
+    init(fileManager: FileManager = .default) {
+        let directory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        fileURL = directory.appendingPathComponent("capturedTasks.json")
+        if let data = try? Data(contentsOf: fileURL),
+           let decoded = try? JSONDecoder().decode([CapturedTask].self, from: data) {
+            cache = decoded
+        }
+    }
+
+    func save(task: CapturedTask) async throws {
+        cache.append(task)
+        try await persist()
+    }
+
+    func update(task: CapturedTask) async throws {
+        if let index = cache.firstIndex(where: { $0.id == task.id }) {
+            cache[index] = task
+            try await persist()
+        }
+    }
+
+    func loadTasks() async -> [CapturedTask] {
+        if cache.isEmpty, let data = try? Data(contentsOf: fileURL) {
+            if let decoded = try? JSONDecoder().decode([CapturedTask].self, from: data) {
+                cache = decoded
+            }
+        }
+        return cache
+    }
+
+    private func persist() async throws {
+        let data = try JSONEncoder().encode(cache)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/VoiceTaskAssistant/ViewModel/TaskCaptureViewModel.swift
+++ b/VoiceTaskAssistant/ViewModel/TaskCaptureViewModel.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Combine
+import SwiftUI
+
+@MainActor
+final class TaskCaptureViewModel: ObservableObject {
+    @Published private(set) var transcriptionText: String = ""
+    @Published private(set) var isRecording: Bool = false
+    @Published private(set) var captureStatusMessage: String?
+    @Published private(set) var pendingTasks: [CapturedTask] = []
+    @Published private(set) var readingSections: [ReadingListSection] = []
+    @Published private(set) var suggestedTags: [String] = []
+    @Published private(set) var readingListError: String?
+
+    private let speechService: SpeechCaptureServicing
+    private let syncCoordinator: SyncCoordinating
+    private let readingListManager: ReadingListManaging
+    private var cancellables = Set<AnyCancellable>()
+
+    init(speechService: SpeechCaptureServicing, syncCoordinator: SyncCoordinating, readingListManager: ReadingListManaging) {
+        self.speechService = speechService
+        self.syncCoordinator = syncCoordinator
+        self.readingListManager = readingListManager
+        bind()
+    }
+
+    func startup() {
+        syncCoordinator.initialize()
+        Task { await refreshTasks() }
+    }
+
+    func resume() {
+        Task { await refreshTasks() }
+    }
+
+    func toggleCapture() {
+        if isRecording {
+            stopCapture()
+        } else {
+            startCapture()
+        }
+    }
+
+    private func startCapture() {
+        captureStatusMessage = "Listening…"
+        speechService.startRecording()
+    }
+
+    private func stopCapture() {
+        speechService.stopRecording()
+    }
+
+    private func bind() {
+        speechService.transcriptionPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] update in
+                self?.transcriptionText = update.text
+                self?.isRecording = update.isRecording
+                self?.captureStatusMessage = update.statusMessage
+            }
+            .store(in: &cancellables)
+
+        speechService.capturedTaskPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] task in
+                guard let self else { return }
+                self.transcriptionText = ""
+                self.captureStatusMessage = "Saved for sync"
+                self.pendingTasks.insert(task, at: 0)
+                self.syncCoordinator.enqueue(task: task)
+            }
+            .store(in: &cancellables)
+
+        syncCoordinator.processedTaskPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] task in
+                guard let index = self?.pendingTasks.firstIndex(where: { $0.id == task.id }) else { return }
+                self?.pendingTasks[index] = task
+            }
+            .store(in: &cancellables)
+
+        syncCoordinator.pendingTasksPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] tasks in
+                self?.pendingTasks = tasks
+                self?.refreshSuggestedTags()
+            }
+            .store(in: &cancellables)
+
+        readingListManager.readingItemsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] items in
+                self?.readingSections = Self.groupReadingItems(items)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refreshTasks() async {
+        let tasks = await syncCoordinator.loadCachedTasks()
+        pendingTasks = tasks.sorted(by: { $0.timestamp > $1.timestamp })
+        refreshSuggestedTags()
+        let items = await readingListManager.loadItems()
+        readingSections = Self.groupReadingItems(items)
+    }
+
+    private func refreshSuggestedTags() {
+        let tags = pendingTasks
+            .compactMap { $0.structured?.topics }
+            .flatMap { $0 }
+        suggestedTags = Array(Set(tags)).sorted()
+    }
+
+    func addArticle(title: String, urlString: String, tags: [String]) async -> Bool {
+        do {
+            _ = try await readingListManager.addManualArticle(title: title, urlString: urlString, tags: tags)
+            readingListError = nil
+            return true
+        } catch {
+            readingListError = "Unable to save article. Check the link and try again."
+            return false
+        }
+    }
+
+    func clearReadingListError() {
+        readingListError = nil
+    }
+
+    private static func groupReadingItems(_ items: [ReadingItem]) -> [ReadingListSection] {
+        var grouped: [String: [ReadingItem]] = [:]
+        var untagged: [ReadingItem] = []
+
+        for item in items {
+            let tags = item.tags
+            if tags.isEmpty {
+                untagged.append(item)
+            } else {
+                for tag in tags {
+                    grouped[tag, default: []].append(item)
+                }
+            }
+        }
+
+        let tagSections = grouped
+            .map { key, value in
+                ReadingListSection(id: key, title: key.capitalized, items: value.sorted(by: { $0.capturedAt > $1.capturedAt }))
+            }
+            .sorted(by: { $0.title < $1.title })
+
+        var sections = tagSections
+        if !untagged.isEmpty {
+            sections.append(
+                ReadingListSection(
+                    id: "untagged",
+                    title: "Untagged",
+                    items: untagged.sorted(by: { $0.capturedAt > $1.capturedAt })
+                )
+            )
+        }
+
+        return sections
+    }
+}
+
+struct ReadingListSection: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let items: [ReadingItem]
+}
+
+#if DEBUG
+struct PreviewSpeechService: SpeechCaptureServicing {
+    var transcriptionPublisher: AnyPublisher<SpeechTranscriptionUpdate, Never> {
+        Just(SpeechTranscriptionUpdate(text: "Buy groceries", isRecording: false, statusMessage: "Preview"))
+            .eraseToAnyPublisher()
+    }
+
+    var capturedTaskPublisher: AnyPublisher<CapturedTask, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func startRecording() {}
+    func stopRecording() {}
+}
+
+struct PreviewSyncCoordinator: SyncCoordinating {
+    var processedTaskPublisher: AnyPublisher<CapturedTask, Never> { Empty().eraseToAnyPublisher() }
+    var pendingTasksPublisher: AnyPublisher<[CapturedTask], Never> {
+        Just([CapturedTask(rawText: "Pick up dry cleaning")]).eraseToAnyPublisher()
+    }
+
+    func initialize() {}
+    func enqueue(task: CapturedTask) {}
+    func loadCachedTasks() async -> [CapturedTask] { [CapturedTask(rawText: "Pick up dry cleaning")] }
+}
+
+struct PreviewReadingListManager: ReadingListManaging {
+    var readingItemsPublisher: AnyPublisher<[ReadingItem], Never> {
+        Just([
+            ReadingItem(title: "Design Systems 101", url: URL(string: "https://example.com/design")!, tags: ["design"], source: .manual)
+        ]).eraseToAnyPublisher()
+    }
+
+    func loadItems() async -> [ReadingItem] {
+        [ReadingItem(title: "Design Systems 101", url: URL(string: "https://example.com/design")!, tags: ["design"], source: .manual)]
+    }
+
+    func upsert(item: ReadingItem) async throws {}
+
+    func addManualArticle(title: String, urlString: String, tags: [String]) async throws -> ReadingItem {
+        ReadingItem(title: title, url: URL(string: urlString)!, tags: tags, source: .manual)
+    }
+}
+#endif

--- a/VoiceTaskAssistant/VoiceTaskAssistantApp.swift
+++ b/VoiceTaskAssistant/VoiceTaskAssistantApp.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import Combine
+
+@main
+struct VoiceTaskAssistantApp: App {
+    @StateObject private var viewModel: TaskCaptureViewModel
+
+    init() {
+        let readingRepository = ReadingListRepository()
+        let deskSyncService = DailyDeskSyncService(readingRepository: readingRepository)
+        let coordinator = SyncCoordinator(
+            repository: TaskRepository(),
+            openAIService: OpenAIService(),
+            deskSyncService: deskSyncService,
+            readingListRepository: readingRepository
+        )
+        _viewModel = StateObject(
+            wrappedValue: TaskCaptureViewModel(
+                speechService: SpeechCaptureService(),
+                syncCoordinator: coordinator,
+                readingListManager: readingRepository
+            )
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a shared reading list model and repository, update the OpenAI prompt, sync coordinator, and CarPlay controller to persist article links alongside tasks
- surface the reading list in the iOS capture app with tag-aware sections and a sheet for manually adding articles
- expand the macOS desk companion with a reading dashboard and local client so desktop users can review and add tagged articles

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d5ad21788324ac001b931806491d)